### PR TITLE
Region `us-east-1` returns as empty string fix

### DIFF
--- a/libraries/aws_s3_bucket.rb
+++ b/libraries/aws_s3_bucket.rb
@@ -103,6 +103,7 @@ class AwsS3Bucket < Inspec.resource(1)
 
   def fetch_region
     @region = AwsS3Bucket::BackendFactory.create.get_bucket_location(bucket: name)
+    return @region = 'us-east-1' unless @region != ''
   end
 
   # Uses the SDK API to really talk to AWS


### PR DESCRIPTION
**Problem**
When the bucket's region is US East (N. Virginia) (otherwise known as `us-east-1`), Amazon S3 returns an empty string for the bucket's region. This only occurs for the us-east-1 region.
The information regarding this is found in the aws docs: http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlocation.html.

**Fix**
If an empty string is returned for region variable then assign it the value 'us-east-1'